### PR TITLE
feat: use lower memory creating workbook

### DIFF
--- a/Xbim.IO.CobieExpress/CobieModel.cs
+++ b/Xbim.IO.CobieExpress/CobieModel.cs
@@ -274,7 +274,7 @@ namespace Xbim.IO.CobieExpress
             report = storage.Log.ToString();
             return loaded;
         }
-
+      
         private static TableStore GetTableStore(IModel model, ModelMapping mapping)
         {
             var storage = new TableStore(model, mapping);


### PR DESCRIPTION
 use lower memory while creating workbook 

recommendation by NPOI if we use file path

* Using an {@link InputStream} requires more memory than using a File, so
*  if a {@link File} is available then you should instead do something like
*   <pre><code>
*       OPCPackage pkg = OPCPackage.open(path);
*       XSSFWorkbook wb = new XSSFWorkbook(pkg);
*       // work with the wb object
*       ......
*       pkg.close(); // gracefully closes the underlying zip file
*   </code></pre>     
*/